### PR TITLE
docs: add breaking changes

### DIFF
--- a/docs/guides/docs/testnet-migration/beta-3-to-beta-4-migration.mdx
+++ b/docs/guides/docs/testnet-migration/beta-3-to-beta-4-migration.mdx
@@ -10,6 +10,8 @@ parent:
 
 This guide focuses on the transition from the end of tool support for `beta 3` to the start of `beta 4`.
 
+> The team is constantly building. For updates on breaking changes beyond this guide, please refer to our bi-weekly report on [GitHub](https://github.com/FuelLabs/breaking-change-log/tree/master) or check announcements in our [forum](https://forum.fuel.network/c/announcements/7).
+
 - [Fuelup v0.19.5](https://github.com/FuelLabs/fuelup/releases/tag/v0.19.5)
 - [Sway v0.45.0](https://github.com/FuelLabs/sway/releases/tag/v0.45.0)
 - [TS SDK v0.57.0](https://github.com/FuelLabs/fuels-ts/releases/tag/v0.57.0)


### PR DESCRIPTION
Biweekly breaking changes across the TS SDK, Sway, Rust SDK now live in a separate repository as well as announcements on Fuel. This is just a short reference to that.