### PR TITLE
docs: Add external links to Sway Standards and Sway Libraries

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -88,6 +88,16 @@ export const NAVIGATION: LinkObject[] = [
         link: 'https://fuellabs.github.io/sway/master/core/',
       },
       {
+        name: 'Sway Standards',
+        type: 'external-link',
+        link: 'https://github.com/FuelLabs/sway-standards/',
+      },
+      {
+        name: 'Sway Libraries',
+        type: 'external-link',
+        link: 'https://github.com/FuelLabs/sway-libs/',
+      },
+      {
         name: 'Tooling',
         type: 'category',
       },

--- a/src/screens/HomePage.tsx
+++ b/src/screens/HomePage.tsx
@@ -65,6 +65,22 @@ export function HomePage({ guides, isLatest }: HomePageProps) {
                 Sway Core
               </FuelLink>
             </List.Item>
+            <List.Item>
+              <FuelLink
+                href="https://github.com/FuelLabs/sway-standards/"
+                isExternal
+              >
+                Sway Standards
+              </FuelLink>
+            </List.Item>
+            <List.Item>
+              <FuelLink
+                href="https://github.com/FuelLabs/sway-libs/"
+                isExternal
+              >
+                Sway Libraries
+              </FuelLink>
+            </List.Item>
           </List>
         </Box.Stack>
       </Box>


### PR DESCRIPTION
Links to the [Sway Standards](https://github.com/FuelLabs/sway-standards) and [Sway Libraries](https://github.com/FuelLabs/sway-libs) were missing from the doc hub. These are essential resources for any developers building in the Sway language.