### PR TITLE
fix code example

### DIFF
--- a/docs/guides/docs/running-a-node/running-a-testnet-node.mdx
+++ b/docs/guides/docs/running-a-node/running-a-testnet-node.mdx
@@ -162,7 +162,7 @@ Finally to put everything together to start the node, run the following command:
 fuel-core run \
 --service-name {ANY_SERVICE_NAME} \
 --keypair {P2P_SECRET} \
---relayer {ETH_RPC_ENDPOINT}\
+--relayer {ETH_RPC_ENDPOINT} \
 --ip 0.0.0.0 --port 4000 --peering-port 30333 \
 --db-path  ~/.fuel_beta5 \
 --chain ./chainConfig.json \


### PR DESCRIPTION
You made a mistake by closing the merge request https://github.com/FuelLabs/docs-hub/pull/187
If you don't use a space before the backslash, bash doesn't understand it correctly and the resulting command will not contain a space
<img width="608" alt="screen1" src="https://github.com/FuelLabs/docs-hub/assets/65978599/022a4d5f-5b9e-466b-a6c0-54674c0d6721">
