### PR TITLE
fix: npm examples

### DIFF
--- a/src/components/CodeTabs.tsx
+++ b/src/components/CodeTabs.tsx
@@ -7,14 +7,19 @@ interface CodeTabsProps {
 
 export function CodeTabs(props: CodeTabsProps) {
   if (props.children) {
+    const npmIsFirst =
+      !props.children[0].props.children.props.__code.includes('pnpm');
+    const order = npmIsFirst
+      ? [props.children[1], props.children[0]]
+      : [props.children[0], props.children[1]];
     return (
       <Tabs css={styles.root} defaultValue="pnpm">
         <Tabs.List css={styles.tabStyles} aria-label="Choose npm or pnpm.">
           <Tabs.Trigger value="pnpm">pnpm</Tabs.Trigger>
           <Tabs.Trigger value="npm">npm</Tabs.Trigger>
         </Tabs.List>
-        <Tabs.Content value="pnpm">{props.children[0]}</Tabs.Content>
-        <Tabs.Content value="npm">{props.children[1]}</Tabs.Content>
+        <Tabs.Content value="pnpm">{order[0]}</Tabs.Content>
+        <Tabs.Content value="npm">{order[1]}</Tabs.Content>
       </Tabs>
     );
   }

--- a/src/components/CodeTabs.tsx
+++ b/src/components/CodeTabs.tsx
@@ -7,11 +7,13 @@ interface CodeTabsProps {
 
 export function CodeTabs(props: CodeTabsProps) {
   if (props.children) {
-    const npmIsFirst =
-      !props.children[0].props.children.props.__code.includes('pnpm');
-    const order = npmIsFirst
-      ? [props.children[1], props.children[0]]
-      : [props.children[0], props.children[1]];
+    let order = [props.children[0], props.children[1]];
+    const firstChildCode =
+      props.children[0].props.children.props.__code ??
+      props.children[0].props.__code;
+    if (firstChildCode && !firstChildCode.includes('pnpm')) {
+      order = [props.children[1], props.children[0]];
+    }
     return (
       <Tabs css={styles.root} defaultValue="pnpm">
         <Tabs.List css={styles.tabStyles} aria-label="Choose npm or pnpm.">

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,10 +11,10 @@ export const FAUCET_LINK = `https://faucet-${FUEL_TESTNET}.fuel.network/`;
 export const BETA_4_FAUCET_LINK = `https://faucet-beta-4.fuel.network/`;
 export const PLAYGROUND_LINK = `https://${FUEL_TESTNET}.fuel.network/playground/`;
 export const BETA_4_PLAYGROUND_LINK = `https://beta-4.fuel.network/playground/`;
-export const EXPLORER_LINK = 'https://app.fuel.network/';
+export const EXPLORER_LINK = 'https://next-app.fuel.network/';
 export const BETA_4_EXPLORER_LINK =
   'https://fuellabs.github.io/block-explorer-v2/beta-4/';
-export const BRIDGE_LINK = 'https://app.fuel.network/portal/bridge';
+export const BRIDGE_LINK = 'https://next-app.fuel.network/bridge';
 
 export type LinkObject = {
   name: string;


### PR DESCRIPTION
fixes an issue with the pnpm/npm examples not showing correctly, as seen here: https://docs.fuel.network/docs/fuels-ts/getting-started/#installing-the-fuels-ts-library

also updates the bridge and explorer links
[update bridge and explorer links](https://github.com/FuelLabs/docs-hub/pull/199/commits/0c47da1ea28730c44713fed26026a476f22d340d)