### PR TITLE
update expired links

### DIFF
--- a/docs/guides/docs/quickstart/building-a-frontend.mdx
+++ b/docs/guides/docs/quickstart/building-a-frontend.mdx
@@ -24,7 +24,7 @@ To build a frontend application for the counter contract, we'll do the following
 Our frontend application will allow users to connect with a wallet, so you'll need to have a browser wallet installed.
 
 <ConditionalContent versionSet={props.versionSet} showForVersions={['default', 'nightly']}>
-Before going to the next steps, install the Fuel Wallet [here](https://chrome.google.com/webstore/detail/fuel-wallet/dldjpboieedgcmpkchcjcbijingjcgok).
+Before going to the next steps, install the Fuel Wallet [here](https://chromewebstore.google.com/detail/fuel-wallet/dldjpboieedgcmpkchcjcbijingjcgok).
 
 If you have previously installed the wallet, make sure you have updated to the latest version.
 </ConditionalContent>


### PR DESCRIPTION
Update expired chrome store link in [documentation](https://docs.fuel.network/docs/intro/quickstart-frontend/#install-the-fuel-browser-wallet)