### PR TITLE
fix: added HTML to syntax highlighter

### DIFF
--- a/src/lib/plugins/rehype-code.ts
+++ b/src/lib/plugins/rehype-code.ts
@@ -101,6 +101,12 @@ const getHighlighter: RehypeCodeOptions['getHighlighter'] = async (options) => {
         scopeName: 'source.sway',
         path: `${pathFolder}/sway.tmLanguage.json`,
       },
+      {
+        id: 'html',
+        name: "html",
+        scopeName: "text.html.basic",
+        path: `${pathFolder}/html.tmLanguage.json`,
+      },
     ],
   });
 


### PR DESCRIPTION
Closes #227

Dependent on https://github.com/FuelLabs/fuels-ts/pull/2031

---

## Summary

Added HTML as a language to the syntax highlighter.

### Before

![image](https://github.com/FuelLabs/docs-hub/assets/16990131/35f2efa1-09ed-43d6-9d17-2e50981f4dcb)

### After

![image](https://github.com/FuelLabs/docs-hub/assets/16990131/782c7cf7-051b-4d04-b56a-cdbaa726df61)
