### PR TITLE
fix: version replacement improvement

### DIFF
--- a/src/lib/plugins/plugins.ts
+++ b/src/lib/plugins/plugins.ts
@@ -65,9 +65,9 @@ const conditions = {
   tsBookVersions: (node: any) => {
     return (
       typeof node.value === 'string' &&
-      (node.value === 'v{{fuels}}' ||
-        node.value === 'v{{fuelCore}}' ||
-        node.value === 'v{{forc}}')
+      (node.value.includes('{{fuels}}') ||
+        node.value.includes('{{fuelCore}}') ||
+        node.value.includes('{{forc}}'))
     );
   },
   // biome-ignore lint/suspicious/noExplicitAny:
@@ -256,14 +256,13 @@ function handleTSDocs(
       const newUrl = handleLinks(node, dirname, idx, parent, newTree);
       if (newUrl) node.url = newUrl;
     } else if (conditions.tsBookVersions(node)) {
-      if (node.value === 'v{{forc}}') {
-        node.value = versions.FORC;
-      } else if (node.value === 'v{{fuels}}') {
-        node.value = versions.FUELS;
-      } else {
-        node.value = versions.FUEL_CORE;
+      if (typeof node.value === 'string') {
+        node.value = node.value
+          .replaceAll('{{fuels}}', versions.FUELS)
+          .replaceAll('{{fuelCore}}', versions.FUEL_CORE)
+          .replaceAll('{{forc}}', versions.FORC);
       }
-    } else if (node.type === 'code' && node.lang === 'ts:line-numbers'){
+    } else if (node.type === 'code' && node.lang === 'ts:line-numbers') {
       node.lang = 'ts';
     } else {
       node.lang = 'sh';


### PR DESCRIPTION
Closes https://github.com/FuelLabs/docs-hub/issues/229

Relates to https://github.com/FuelLabs/fuels-ts/issues/1960

## Summary

Improved the replacement for versions for the TypeScript documentation.

### Before

![image](https://github.com/FuelLabs/docs-hub/assets/16990131/13c28fea-d1d1-4369-805a-cff8fb9b3eb6)

### After

![image](https://github.com/FuelLabs/docs-hub/assets/16990131/ec2f7b41-72f2-420f-9d18-1789a7872521)


