### PR TITLE
fix: change logs url in index.mdx

### DIFF
--- a/docs/guides/docs/migration-guide/index.mdx
+++ b/docs/guides/docs/migration-guide/index.mdx
@@ -13,4 +13,4 @@ Given the dynamic nature of learning and adapting during these testing phases, i
 
 ## Breaking Changes
 
-Learn how to migrate to the latest versions of the Fuel toolchain and SDKs in the [Breaking Changes Log](/guides/migration-guide/breaking-changes-log).
+Learn how to migrate to the latest versions of the Fuel toolchain and SDKs in the [Breaking Changes Log](https://github.com/FuelLabs/breaking-change-log/tree/72f4d58126793c0f6d19a4ab65ce0742503485d6).


### PR DESCRIPTION
Just corrected the Braking Changes Log's url in `docs/guides/docs/migration-guide/index.mdx` file.