### PR TITLE
chore: upgraded `upload-artifact` GitHub Action

### DIFF
--- a/.github/workflows/guides.yml
+++ b/.github/workflows/guides.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Playwright tests for ${{ matrix.guide }}
         run: xvfb-run --auto-servernum pnpm test:guides --grep "${{ matrix.guide }}"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report-${{ matrix.guide }}


### PR DESCRIPTION
Update `actions/upload-artifact` from `v2` to `v4` due to [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) (scheduled for June 30, 2024). 
