### PR TITLE
docs: fix invalid links

### DIFF
--- a/docs/contributing/documentation.mdx
+++ b/docs/contributing/documentation.mdx
@@ -22,7 +22,7 @@ Below, you will find a list indicating the locations of the source documentation
 
 ## Style Guide
 
-See the [Style Guide](/docs/contributing/style-guide) for guidance on how to edit or write documentation.
+See the [Style Guide](/docs/contributing/style-guide.mdx) for guidance on how to edit or write documentation.
 
 ## Docs-related GitHub workflows
 

--- a/docs/contributing/github-workflows.mdx
+++ b/docs/contributing/github-workflows.mdx
@@ -29,7 +29,7 @@ If the spell check test fails:
 - If possible, rewrite the sentence.
 - If it otherwise should be ignored, you can configure the pipeline in `.spellcheck.yml`.
 
-To fix a failed guides test, refer to the [Guides Testing](/docs/contributing/guides/#testing) section.
+To fix a failed guides test, refer to the [Guides Testing](/docs/contributing/guides.mdx/#testing) section.
 
 ## Links (`links.yml` )
 

--- a/docs/contributing/guides.mdx
+++ b/docs/contributing/guides.mdx
@@ -16,7 +16,7 @@ Note that the some content is pulled in from submodules. To make any changes to 
 
 ## Style Guide
 
-See the [Style Guide](/docs/contributing/style-guide) for guidance on how to edit or write guides.
+See the [Style Guide](/docs/contributing/style-guide.mdx) for guidance on how to edit or write guides.
 
 ## Testing
 

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -13,9 +13,9 @@ parent:
 Before you get started, please take a moment to read through this contributing guide.
 It contains important information and helpful tips for contributing to the Fuel documentation and guides.
 
-- [General](/docs/contributing/general)
-- [Documentation](/docs/contributing/documentation)
-- [Guides](/docs/contributing/guides)
-- [Style Guide](/docs/contributing/style-guide)
-- [Versions](/docs/contributing/versions)
-- [GitHub Workflows](/docs/contributing/github-workflows)
+- [General](/docs/contributing/general.mdx)
+- [Documentation](/docs/contributing/documentation.mdx)
+- [Guides](/docs/contributing/guides.mdx)
+- [Style Guide](/docs/contributing/style-guide.mdx)
+- [Versions](/docs/contributing/versions.mdx)
+- [GitHub Workflows](/docs/contributing/github-workflows.mdx)


### PR DESCRIPTION
Hello. I've found that some links were invalid. Most of them were missing the ‘.mdx’ extension, which is now fixed. 

Hope this fix helps.