### PR TITLE
docs: update fuelup version in installation guide

### DIFF
--- a/docs/guides/docs/installation/index.mdx
+++ b/docs/guides/docs/installation/index.mdx
@@ -70,7 +70,7 @@ After allowing the `fuelup-init` script to modify your `PATH` variable, you will
 ```sh
 The Fuel toolchain is installed and up to date
 
-fuelup 0.20.0 has been installed in /home/username/.fuelup/bin. 
+fuelup 0.28.1 has been installed in /home/username/.fuelup/bin.
 To fetch the latest toolchain containing the forc and fuel-core binaries, run 'fuelup toolchain install latest'. 
 To generate completions for your shell, run 'fuelup completions --shell=SHELL'.
 ```
@@ -84,7 +84,7 @@ To generate completions for your shell, run 'fuelup completions --shell=SHELL'.
 That will output your current `fuelup` version:
 
 ```sh
-fuelup 0.21.0
+fuelup 0.28.1
 ```
 
 ### VSCode extensions
@@ -114,7 +114,7 @@ fuelup self update
 Then you will get an output like this:
 
 ```sh
-Fetching binary from https://github.com/FuelLabs/fuelup/releases/download/v0.19.5/fuelup-0.19.5-aarch64-apple-darwin.tar.gz
+Fetching binary from https://github.com/FuelLabs/fuelup/releases/download/v0.28.1/fuelup-0.28.1-aarch64-apple-darwin.tar.gz
 Downloading component fuelup without verifying checksum
 Unpacking and moving fuelup to /var/folders/tp/0l8zdx9j4s9_n609ykwxl0qw0000gn/T/.tmpiNJQHt
 Moving /var/folders/tp/0l8zdx9j4s9_n609ykwxl0qw0000gn/T/.tmpiNJQHt/fuelup to /Users/.fuelup/bin/fuelup


### PR DESCRIPTION
## Summary

Fixes #774.

Updates the installation guide examples to show the current latest `fuelup` release, `0.28.1`, instead of the stale `0.20.0`, `0.21.0`, and `0.19.5` values.

I checked the latest release from `FuelLabs/fuelup` before updating the examples.

## Testing

- `pnpm lint:guides:check`

Note: the command passes and prints an existing Node `punycode` deprecation warning from dependencies.