### PR TITLE
fix: make Vercel builds deterministic

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -2,10 +2,11 @@ name: "CI setup"
 inputs:
   node-version:
     description: "Node version"
-    default: 20.10.0
+    default: 22.13.1
   pnpm-version:
-    description: "PNPM version"
-    default: latest
+    description: "PNPM major used in the cache key"
+    # The exact installed version comes from package.json#packageManager.
+    default: 9
   install:
     description: "Should install?"
     default: true
@@ -28,5 +29,4 @@ runs:
     - name: Setup PNPM
       uses: pnpm/action-setup@v4
       with:
-        version: ${{ inputs.pnpm-version }}
         run_install: ${{ inputs.install }}

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,19 @@ const HAS_LINK_DEPS = Boolean(
   (process.env.LINK_DEPS?.trim().split(' ').filter(Boolean) || []).length
 );
 
+const configureWebpack = (config, options) => {
+  if (options.isServer) {
+    config.resolve.alias['plyr-react$'] = path.resolve(
+      __dirname,
+      'src',
+      'components',
+      'PlyrServerStub.tsx'
+    );
+  }
+
+  return config;
+};
+
 const depsLinkOpts = {
   transpilePackages: [
     '@fuel-ui/react',
@@ -13,6 +26,8 @@ const depsLinkOpts = {
     '@fuel-ui/tokens',
   ],
   webpack: (config, options) => {
+    config = configureWebpack(config, options);
+
     if (options.isServer) {
       config.externals = ['react', ...config.externals];
     }
@@ -153,6 +168,7 @@ const nextConfig = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
+  webpack: configureWebpack,
   ...(HAS_LINK_DEPS ? depsLinkOpts : {}),
 };
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "docs",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "build": "next build",
     "build:ci": "run-s docs:sync docs:clean generate:* patch:wallet build",
@@ -135,6 +139,9 @@
       "unist-util-visit@<5.0.0": "5.0.0",
       "rehype-pretty-code@>0.10.0": "0.10.0",
       "shiki@>0.14.4": "0.14.4"
+    },
+    "patchedDependencies": {
+      "@contentlayer/cli@0.3.4": "patches/@contentlayer__cli@0.3.4.patch"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -142,6 +142,10 @@
     },
     "patchedDependencies": {
       "@contentlayer/cli@0.3.4": "patches/@contentlayer__cli@0.3.4.patch"
-    }
+    },
+    "neverBuiltDependencies": [
+      "@fuel-ts/forc",
+      "@fuel-ts/fuel-core"
+    ]
   }
 }

--- a/patches/@contentlayer__cli@0.3.4.patch
+++ b/patches/@contentlayer__cli@0.3.4.patch
@@ -1,0 +1,43 @@
+diff --git a/dist/commands/_BaseCommand.js b/dist/commands/_BaseCommand.js
+index 5f7892637c185d36d9e489b803d8df450f4f7f1b..70e473a8b3256ec00a63fd90cd9f0051bc1381e6 100644
+--- a/dist/commands/_BaseCommand.js
++++ b/dist/commands/_BaseCommand.js
+@@ -17,10 +17,12 @@ export class BaseCommand extends Command {
+         this.verbose = Option.Boolean('--verbose', false, {
+             description: 'More verbose logging and error stack traces',
+         });
+-        this.execute = () => pipe(this.executeSafe(), core.runMain({
+-            tracingServiceName: 'contentlayer-cli',
+-            verbose: this.verbose || process.env.CL_DEBUG !== undefined,
+-        }));
++        this.execute = async () => {
++            await pipe(this.executeSafe(), core.runMain({
++                tracingServiceName: 'contentlayer-cli',
++                verbose: this.verbose || process.env.CL_DEBUG !== undefined,
++            }));
++        };
+         this.clearCacheIfNeeded = () => {
+             const { clearCache } = this;
+             return T.gen(function* ($) {
+diff --git a/src/commands/_BaseCommand.ts b/src/commands/_BaseCommand.ts
+index 1e8f998f268cee2bd0ea907c7878eb5fdf0e6b47..a5876ec1fa5fa22bfb1b7fa04b527499e8289581 100644
+--- a/src/commands/_BaseCommand.ts
++++ b/src/commands/_BaseCommand.ts
+@@ -23,14 +23,15 @@ export abstract class BaseCommand extends Command {
+ 
+   abstract executeSafe: () => T.Effect<OT.HasTracer & HasClock & HasCwd & HasConsole & fs.HasFs, unknown, void>
+ 
+-  execute = (): Promise<void> =>
+-    pipe(
++  execute = async (): Promise<void> => {
++    await pipe(
+       this.executeSafe(),
+       core.runMain({
+         tracingServiceName: 'contentlayer-cli',
+         verbose: this.verbose || process.env.CL_DEBUG !== undefined,
+       }),
+     )
++  }
+ 
+   clearCacheIfNeeded = () => {
+     const { clearCache } = this

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,11 @@ overrides:
   rehype-pretty-code@>0.10.0: 0.10.0
   shiki@>0.14.4: 0.14.4
 
+patchedDependencies:
+  '@contentlayer/cli@0.3.4':
+    hash: wsqkogorprvpmjrdlcyumyot64
+    path: patches/@contentlayer__cli@0.3.4.patch
+
 importers:
 
   .:
@@ -11251,7 +11256,7 @@ snapshots:
       preact: 10.22.0
       sha.js: 2.4.11
 
-  '@contentlayer/cli@0.3.4(esbuild@0.25.3)':
+  '@contentlayer/cli@0.3.4(patch_hash=wsqkogorprvpmjrdlcyumyot64)(esbuild@0.25.3)':
     dependencies:
       '@contentlayer/core': 0.3.4(esbuild@0.25.3)
       '@contentlayer/utils': 0.3.4
@@ -16894,7 +16899,7 @@ snapshots:
 
   contentlayer@0.3.4(esbuild@0.25.3):
     dependencies:
-      '@contentlayer/cli': 0.3.4(esbuild@0.25.3)
+      '@contentlayer/cli': 0.3.4(patch_hash=wsqkogorprvpmjrdlcyumyot64)(esbuild@0.25.3)
       '@contentlayer/client': 0.3.4(esbuild@0.25.3)
       '@contentlayer/core': 0.3.4(esbuild@0.25.3)
       '@contentlayer/source-files': 0.3.4(esbuild@0.25.3)

--- a/scripts/clean-build-files.mjs
+++ b/scripts/clean-build-files.mjs
@@ -3,7 +3,13 @@ import path from 'path';
 import toml from 'toml';
 
 const swayManifest = fs.readFileSync('./docs/sway/Cargo.toml', 'utf8');
+const nightlySwayManifest = fs.readFileSync(
+  './docs/nightly/sway/Cargo.toml',
+  'utf8'
+);
 const defaultSwayVersion = toml.parse(swayManifest).workspace.package.version;
+const nightlySwayVersion =
+  toml.parse(nightlySwayManifest).workspace.package.version;
 
 // List of directories to delete unused files from
 const targetDirs = [
@@ -51,7 +57,6 @@ const exclusions = {
     'sway/docs/book/src',
     'sway/examples',
     'sway/master/book',
-    `sway/v${defaultSwayVersion}/book`,
     'sway/test/src/sdk-harness/test_projects/run_external_proxy',
     'sway/test/src/sdk-harness/test_projects/run_external_target',
   ],
@@ -105,7 +110,13 @@ function main() {
     // Change to the target directory
     process.chdir(targetDir);
     const dirBasename = path.basename(targetDir).replace(/-/g, '_');
-    const currentExclusions = exclusions[dirBasename];
+    const swayVersion = targetDir.startsWith('./docs/nightly/')
+      ? nightlySwayVersion
+      : defaultSwayVersion;
+    const currentExclusions = [
+      ...(exclusions[dirBasename] ?? []),
+      ...(dirBasename === 'sway' ? [`sway/v${swayVersion}/book`] : []),
+    ];
     cleanupFiles(currentExclusions, '.');
     // console.log(`Cleanup done for ${targetDir}!`);
     // Return to the original directory

--- a/scripts/clean-build-files.mjs
+++ b/scripts/clean-build-files.mjs
@@ -1,5 +1,9 @@
 import fs from 'fs';
 import path from 'path';
+import toml from 'toml';
+
+const swayManifest = fs.readFileSync('./docs/sway/Cargo.toml', 'utf8');
+const defaultSwayVersion = toml.parse(swayManifest).workspace.package.version;
 
 // List of directories to delete unused files from
 const targetDirs = [
@@ -47,6 +51,7 @@ const exclusions = {
     'sway/docs/book/src',
     'sway/examples',
     'sway/master/book',
+    `sway/v${defaultSwayVersion}/book`,
     'sway/test/src/sdk-harness/test_projects/run_external_proxy',
     'sway/test/src/sdk-harness/test_projects/run_external_target',
   ],

--- a/scripts/generate-sitemap/generateSitemap.mjs
+++ b/scripts/generate-sitemap/generateSitemap.mjs
@@ -1,4 +1,18 @@
-import { allMdDocs } from '../../.contentlayer/generated/index.mjs';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// The generated index.mjs imports its JSON with `assert { type: 'json' }`,
+// which Node.js 22+ rejects, so read the generated document list directly.
+const allMdDocs = JSON.parse(
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../.contentlayer/generated/MdDoc/_index.json'
+    ),
+    'utf8'
+  )
+);
 
 export function generateSiteMap() {
   const paths = getAllPaths(allMdDocs).map((p) => {

--- a/src/components/PlyrServerStub.tsx
+++ b/src/components/PlyrServerStub.tsx
@@ -1,0 +1,3 @@
+export default function PlyrServerStub() {
+  return null;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "pnpm install",
   "buildCommand": "pnpm build:ci",
   "github": {
     "silent": true


### PR DESCRIPTION
## Summary

- pin the supported Node 22 and pnpm 9 toolchain across Vercel and GitHub Actions
- remove the Vercel install override so the package-manager pin is respected
- make Contentlayer, sitemap generation, and Plyr server rendering compatible with Node 22
- preserve the exact versioned Sway/Forc documentation artifacts during cleanup
- skip install-time downloads for the unused legacy @fuel-ts/forc and @fuel-ts/fuel-core binaries

## Context

This build-system work was extracted from #961 so that PR can remain focused on documentation updates. This PR should merge before #961.

## Verification

Using Node 22.13.1 and pnpm 9.15.9 on a branch based directly on master:

- pnpm install --frozen-lockfile --force --offline
- pnpm check:prod
- pnpm build:ci

The forced fresh install completed without the legacy binary download scripts, and the full build generated 1,056 Contentlayer documents and all 1,059 static pages.