### PR TITLE
docs: add AI resources and descriptions

### DIFF
--- a/docs/ai/docs/src/index.md
+++ b/docs/ai/docs/src/index.md
@@ -11,5 +11,7 @@ Alternatively, if you prefer a more structured format with separate Markdown fil
 ## Resources
 
 - [Fuel Network Skills](https://github.com/FuelLabs/fuel-network-skills) — a version-pinned agent skill for Claude Code and compatible tools, with self-contained references covering the full Fuel stack (Sway, Forc, the FuelVM, SDKs, transactions, and security review)
-- [Context7 MCP Server](https://context7.com/fuellabs/markdown)
-- [Devin's DeepWiki](https://deepwiki.com/FuelLabs)
+- [Fuel Connectors Skill](https://github.com/rishabhkeshan/fuel-connectors-skill) — an app-agnostic skill for integrating Fuel wallets with `@fuels/connectors` and `@fuels/react`, including connector APIs, hooks, WalletConnect, Solana, and BakoSafe multisig flows
+- [Fuel–Stork Integration](https://github.com/rishabhkeshan/fuel-stork-integration) — a Claude Code skill and standalone guide for using Stork price feeds on Fuel, covering push and pull feeds, Sway consumers, TypeScript pushers, tests, and common integration failures
+- [Context7 MCP Server](https://context7.com/fuellabs/markdown) — a Fuel documentation index for bringing library context into AI agents and coding tools through Context7
+- [Devin's DeepWiki](https://deepwiki.com/FuelLabs) — an AI-generated wiki and repository Q&A interface for exploring FuelLabs codebases


### PR DESCRIPTION
## Summary

- add Fuel Connectors Skill and Fuel–Stork Integration resources to the AI page
- add descriptions for the existing Context7 and DeepWiki entries

## Validation

- Markdownlint 0.32.1
- git diff --check
- affected resource links return HTTP 200